### PR TITLE
Fix Error on cellEnter

### DIFF
--- a/src/Layers/FeatureLayer/FeatureGrid.js
+++ b/src/Layers/FeatureLayer/FeatureGrid.js
@@ -117,7 +117,10 @@ export var FeatureGrid = Layer.extend({
   cellLeave: function () {
     return;
   },
-
+  
+  cellEnter: function(){
+    return;
+  },
   // @section
   // @method getCellSize: Point
   // Normalizes the [cellSize option](#gridlayer-cellsize) into a point. Used by the `createCell()` method.

--- a/src/Layers/FeatureLayer/FeatureGrid.js
+++ b/src/Layers/FeatureLayer/FeatureGrid.js
@@ -117,8 +117,8 @@ export var FeatureGrid = Layer.extend({
   cellLeave: function () {
     return;
   },
-  
-  cellEnter: function(){
+
+  cellEnter: function () {
     return;
   },
   // @section


### PR DESCRIPTION
When zoomingOut, cellEnter was fired on FeatureGrid but was undefined